### PR TITLE
Don't hardcode path to fish executable

### DIFF
--- a/install.fish
+++ b/install.fish
@@ -1,4 +1,4 @@
-#! /usr/bin/fish
+#! /usr/bin/env fish
 
 echo "
 


### PR DESCRIPTION
Hi,

this is excitingly small fix for the `install.fish` script being broken on Apple M1 if using Homebrew (and its defaults),
for which location is: `/opt/homebrew`.

So let's get the `fish` exec path using `env`, as well as it's done in `install.sh` already.

Best regards,
Peter